### PR TITLE
Fix override reactors, portals, and HSU activators

### DIFF
--- a/LGTuner/Inject/Inject_BuildGeomorph.cs
+++ b/LGTuner/Inject/Inject_BuildGeomorph.cs
@@ -134,6 +134,18 @@ namespace LGTuner.Inject
                     Logger.Error($" - Area count and AreaSeeds item count mismatched! (CFG: {overrideData.AreaSeeds.Length} != AREA: {__result.m_areas.Length}) Area seed will not be applied!");
                 }
             }
+
+            // the following gets run on its own if there's a LevelLayoutDB Custom Geo
+            if (!zone.m_settings.HasCustomGeomorphPrefab)
+            {
+                iLG_CustomGeomorphLogic[] componentsInChildren = __result.GetComponentsInChildren<iLG_CustomGeomorphLogic>();
+                for (int i = 0; i < componentsInChildren.Length; i++)
+                {
+                    componentsInChildren[i].SpawnedOnFloor();
+                    LG_Factory.InjectJob(new LG_CustomGeomorphBuildJob(componentsInChildren[i]), LG_Factory.BatchName.CustomGeomorphBuildJob);
+                    LG_Factory.InjectJob(new LG_CustomGeomorphPostCullingJob(componentsInChildren[i]), LG_Factory.BatchName.CustomGeomorphPostCullingJob);
+                }
+            }
         }
     }
 }

--- a/LGTuner/Inject/Inject_BuildPlug.cs
+++ b/LGTuner/Inject/Inject_BuildPlug.cs
@@ -124,7 +124,7 @@ namespace LGTuner.Inject
                 return false;
             }
 
-            prefab = AssetAPI.GetLoadedAsset(prefabPath).Cast<GameObject>();
+            prefab = AssetAPI.GetLoadedAsset(prefabPath)?.Cast<GameObject>();
             return prefab != null;
         }
 


### PR DESCRIPTION
Actually inject the jobs needed for properly setting up `iLG_CustomGeomorphLogic` scripts, allowing LGTune'd Reactor tiles, MWP Portals, and neonate HSU activators to function

Also, don't explode level gen if you try to override a plug that isn't loaded